### PR TITLE
feat: add charging history and schedule tools

### DIFF
--- a/.claude/skills/rivian-api.md
+++ b/.claude/skills/rivian-api.md
@@ -102,6 +102,16 @@ All `TimeStampedString` or `TimeStampedInt` with `{ timeStamp, value }`:
 - `otaDownloadProgress` — download progress (0-100)
 - `otaInstallDuration` / `otaInstallTime` / `otaInstallType`
 
+### `getChargingHistory()`
+Returns all completed charging sessions. No parameters needed — returns all sessions for the authenticated user.
+Key fields: `startInstant`, `endInstant`, `totalEnergyKwh`, `rangeAddedKm`, `paidTotal`, `currencyCode`, `city`, `vendor`, `chargerType`, `isHomeCharger`, `isRoamingNetwork`, `isPublic`.
+
+### `getChargingSchedule(vehicleId)`
+Returns configured charging schedules. Key fields:
+- `startTime` — minutes from midnight (e.g., 1320 = 10:00 PM)
+- `duration` — minutes (e.g., 360 = 6 hours)
+- `amperage`, `enabled`, `weekDays`, `location { latitude, longitude }`
+
 ## Known Read-Only Queries (Not Yet Implemented)
 
 These queries exist in the Rivian API and could be added as read-only functions:
@@ -112,11 +122,9 @@ These queries exist in the Rivian API and could be added as read-only functions:
 - `getVehicleLastConnection(vehicleId)` — last cloud connection time
 - `planTrip(...)` — route planning with charging stops
 - `getNearbyChargingSites(...)` — nearby chargers with availability
-- `getChargingSchedule(vehicleId)` — current charging schedule
 - `getVehicleImages(vehicleId)` — vehicle renders/photos
 
 ### Charging (`chrg/user/graphql`)
-- `getChargingHistory(vehicleId)` — past charging sessions
 - `getChargingSiteDetails(siteId)` — charger details, pricing, availability
 
 ### Orders (`orders/graphql`)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Your session is saved to `~/.rivian-mcp/session.json` and reused automatically u
 - "Show me the full vehicle status"
 - "Who has keys to my R1S?"
 - "Am I currently charging?"
+- "Show my charging history"
+- "What's my charging schedule?"
 
 ## Tools
 
@@ -64,12 +66,20 @@ Your session is saved to `~/.rivian-mcp/session.json` and reused automatically u
 | `rivian_get_vehicle_state` | Live status — battery, doors, tires, location, climate, OTA |
 | `rivian_get_ota_status` | Current and available software versions |
 | `rivian_get_charging_session` | Active charging session details |
+| `rivian_get_charging_history` | Past charging sessions — energy, cost, location |
+| `rivian_get_charging_schedule` | Your configured charging schedule |
 | `rivian_get_drivers_and_keys` | Drivers and their phone keys / key fobs |
 
 ## Requirements
 
 - Node.js 24+
 - A Rivian account with a vehicle
+
+## Support
+
+If you're thinking about getting a Rivian and don't have a referral yet, here's mine — you'll get benefits on your purchase and it helps support this project:
+
+[Get a Rivian R1 with referral benefits](https://rivian.com/configurations/list?reprCode=PATRICK4568756)
 
 ## References
 

--- a/lib/rivian.js
+++ b/lib/rivian.js
@@ -221,6 +221,55 @@ export async function getLiveChargingSession(vehicleId) {
   return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getLiveSessionData;
 }
 
+export async function getChargingHistory() {
+  const body = {
+    operationName: 'getCompletedSessionSummaries',
+    query: `query getCompletedSessionSummaries {
+  getCompletedSessionSummaries {
+    chargerType
+    currencyCode
+    paidTotal
+    startInstant
+    endInstant
+    totalEnergyKwh
+    rangeAddedKm
+    city
+    transactionId
+    vehicleId
+    vehicleName
+    vendor
+    isRoamingNetwork
+    isPublic
+    isHomeCharger
+  }
+}`,
+    variables: {},
+  };
+
+  return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getCompletedSessionSummaries;
+}
+
+export async function getChargingSchedule(vehicleId) {
+  const body = {
+    operationName: 'GetChargingSchedule',
+    query: `query GetChargingSchedule($vehicleId: String!) {
+  getVehicle(id: $vehicleId) {
+    chargingSchedules {
+      startTime
+      duration
+      location { latitude longitude }
+      amperage
+      enabled
+      weekDays
+    }
+  }
+}`,
+    variables: { vehicleId },
+  };
+
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle;
+}
+
 export async function getDriversAndKeys(vehicleId) {
   const body = {
     operationName: 'DriversAndKeys',


### PR DESCRIPTION
## Summary

- Add `rivian_get_charging_history` tool — view past charging sessions with energy, cost, duration, and location
- Add `rivian_get_charging_schedule` tool — see configured charge windows (time, amperage, days)
- Add referral link to README

## Details

**Charging history** queries `getCompletedSessionSummaries` on the charging endpoint. Returns all past sessions formatted with date/time, duration, location, energy (kWh), range added (km→miles), and cost.

**Charging schedule** queries `GetChargingSchedule` on the gateway endpoint. Formats start/end times from minutes-from-midnight into human-readable 12h format, shows amperage, enabled status, and day-of-week schedule.

Both are strictly read-only.

## Test plan

- [x] Log in and run `rivian_get_charging_history` — verify sessions list with dates, energy, cost
- [x] Run `rivian_get_charging_schedule` — verify schedule displays correctly
- [x] Verify no regressions on existing tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)