### PR TITLE
fix: consolidate session state into a single object

### DIFF
--- a/lib/rivian.js
+++ b/lib/rivian.js
@@ -18,15 +18,17 @@ const BASE_HEADERS = {
 
 // ── Session state ───────────────────────────────────────────────────
 
-let csrfToken = '';
-let appSessionToken = '';
-let accessToken = '';
-let refreshToken = '';
-let userSessionToken = '';
-let otpToken = '';
+const session = {
+  csrfToken: '',
+  appSessionToken: '',
+  accessToken: '',
+  refreshToken: '',
+  userSessionToken: '',
+  otpToken: '',
+};
 
-export const needsOtp = () => !!otpToken;
-export const isAuthenticated = () => !!accessToken;
+export const needsOtp = () => !!session.otpToken;
+export const isAuthenticated = () => !!session.accessToken;
 
 // ── Auth ────────────────────────────────────────────────────────────
 
@@ -42,8 +44,8 @@ export async function createCsrfToken() {
 }`,
     variables: null,
   });
-  csrfToken = data.createCsrfToken.csrfToken;
-  appSessionToken = data.createCsrfToken.appSessionToken;
+  session.csrfToken = data.createCsrfToken.csrfToken;
+  session.appSessionToken = data.createCsrfToken.appSessionToken;
 }
 
 export async function login(email, password) {
@@ -68,17 +70,17 @@ export async function login(email, password) {
 }`,
       variables: { email, password },
     },
-    { 'Csrf-Token': csrfToken, 'A-Sess': appSessionToken },
+    { 'Csrf-Token': session.csrfToken, 'A-Sess': session.appSessionToken },
   );
 
   if (data.login.otpToken) {
-    otpToken = data.login.otpToken;
+    session.otpToken = data.login.otpToken;
     return { mfa: true };
   }
 
-  accessToken = data.login.accessToken;
-  refreshToken = data.login.refreshToken;
-  userSessionToken = data.login.userSessionToken;
+  session.accessToken = data.login.accessToken;
+  session.refreshToken = data.login.refreshToken;
+  session.userSessionToken = data.login.userSessionToken;
   return { mfa: false };
 }
 
@@ -98,15 +100,15 @@ export async function validateOtp(email, otpCode) {
     }
   }
 }`,
-      variables: { email, otpCode, otpToken },
+      variables: { email, otpCode, otpToken: session.otpToken },
     },
-    { 'Csrf-Token': csrfToken, 'A-Sess': appSessionToken },
+    { 'Csrf-Token': session.csrfToken, 'A-Sess': session.appSessionToken },
   );
 
-  accessToken = data.loginWithOTP.accessToken;
-  refreshToken = data.loginWithOTP.refreshToken;
-  userSessionToken = data.loginWithOTP.userSessionToken;
-  otpToken = '';
+  session.accessToken = data.loginWithOTP.accessToken;
+  session.refreshToken = data.loginWithOTP.refreshToken;
+  session.userSessionToken = data.loginWithOTP.userSessionToken;
+  session.otpToken = '';
 }
 
 // ── Read-only queries ───────────────────────────────────────────────
@@ -300,34 +302,29 @@ export async function getDriversAndKeys(vehicleId) {
 
 export function exportSession() {
   return {
-    csrfToken,
-    appSessionToken,
-    accessToken,
-    refreshToken,
-    userSessionToken,
-    otpToken,
-    needsOtp: !!otpToken,
-    authenticated: !!accessToken,
+    ...session,
+    needsOtp: !!session.otpToken,
+    authenticated: !!session.accessToken,
   };
 }
 
-export function restoreSession(session) {
-  csrfToken = session.csrfToken || '';
-  appSessionToken = session.appSessionToken || '';
-  accessToken = session.accessToken || '';
-  refreshToken = session.refreshToken || '';
-  userSessionToken = session.userSessionToken || '';
-  otpToken = session.otpToken || '';
+export function restoreSession(saved) {
+  session.csrfToken = saved.csrfToken || '';
+  session.appSessionToken = saved.appSessionToken || '';
+  session.accessToken = saved.accessToken || '';
+  session.refreshToken = saved.refreshToken || '';
+  session.userSessionToken = saved.userSessionToken || '';
+  session.otpToken = saved.otpToken || '';
 }
 
 // ── Internals ───────────────────────────────────────────────────────
 
 function authHeaders() {
-  return { 'A-Sess': appSessionToken, 'U-Sess': userSessionToken };
+  return { 'A-Sess': session.appSessionToken, 'U-Sess': session.userSessionToken };
 }
 
 function chargingHeaders() {
-  return { 'U-Sess': userSessionToken };
+  return { 'U-Sess': session.userSessionToken };
 }
 
 async function gql(url, body, extraHeaders = {}) {


### PR DESCRIPTION
## Summary

- Replace six module-level `let` variables with a single `const session` object
- `exportSession()` simplified to `{ ...session, needsOtp, authenticated }`
- `restoreSession()` parameter renamed `saved` to avoid shadowing the module-level `session`

No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)