### PR TITLE
chore: add ESLint and Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ Your session is saved to `~/.rivian-mcp/session.json` and reused automatically u
 
 ## Tools
 
-| Tool | What it does |
-|---|---|
-| `rivian_login` | Start sign-in (triggers verification code) |
-| `rivian_submit_otp` | Complete sign-in with the verification code |
-| `rivian_get_user_info` | Your account, vehicles, and software versions |
-| `rivian_get_vehicle_state` | Live status — battery, doors, tires, location, climate, OTA |
-| `rivian_get_ota_status` | Current and available software versions |
-| `rivian_get_charging_session` | Active charging session details |
-| `rivian_get_charging_history` | Past charging sessions — energy, cost, location |
-| `rivian_get_charging_schedule` | Your configured charging schedule |
-| `rivian_get_drivers_and_keys` | Drivers and their phone keys / key fobs |
+| Tool                           | What it does                                                |
+| ------------------------------ | ----------------------------------------------------------- |
+| `rivian_login`                 | Start sign-in (triggers verification code)                  |
+| `rivian_submit_otp`            | Complete sign-in with the verification code                 |
+| `rivian_get_user_info`         | Your account, vehicles, and software versions               |
+| `rivian_get_vehicle_state`     | Live status — battery, doors, tires, location, climate, OTA |
+| `rivian_get_ota_status`        | Current and available software versions                     |
+| `rivian_get_charging_session`  | Active charging session details                             |
+| `rivian_get_charging_history`  | Past charging sessions — energy, cost, location             |
+| `rivian_get_charging_schedule` | Your configured charging schedule                           |
+| `rivian_get_drivers_and_keys`  | Drivers and their phone keys / key fobs                     |
 
 ## Requirements
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+import globals from 'globals'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-undef': 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'no-var': 'error',
+      'prefer-const': 'error',
+    },
+  },
+  prettier,
+]

--- a/lib/rivian.js
+++ b/lib/rivian.js
@@ -5,28 +5,28 @@
  * No write/post/patch mutations — only auth and queries.
  */
 
-const GRAPHQL_GATEWAY = 'https://rivian.com/api/gql/gateway/graphql';
-const GRAPHQL_CHARGING = 'https://rivian.com/api/gql/chrg/user/graphql';
-const APOLLO_CLIENT_NAME = 'com.rivian.ios.consumer-apollo-ios';
+const GRAPHQL_GATEWAY = 'https://rivian.com/api/gql/gateway/graphql'
+const GRAPHQL_CHARGING = 'https://rivian.com/api/gql/chrg/user/graphql'
+const APOLLO_CLIENT_NAME = 'com.rivian.ios.consumer-apollo-ios'
 
 const BASE_HEADERS = {
   'User-Agent': 'RivianApp/707 CFNetwork/1237 Darwin/20.4.0',
-  'Accept': 'application/json',
+  Accept: 'application/json',
   'Content-Type': 'application/json',
   'Apollographql-Client-Name': APOLLO_CLIENT_NAME,
-};
+}
 
 // ── Session state ───────────────────────────────────────────────────
 
-let csrfToken = '';
-let appSessionToken = '';
-let accessToken = '';
-let refreshToken = '';
-let userSessionToken = '';
-let otpToken = '';
+let csrfToken = ''
+let appSessionToken = ''
+let accessToken = ''
+let refreshToken = ''
+let userSessionToken = ''
+let otpToken = ''
 
-export const needsOtp = () => !!otpToken;
-export const isAuthenticated = () => !!accessToken;
+export const needsOtp = () => !!otpToken
+export const isAuthenticated = () => !!accessToken
 
 // ── Auth ────────────────────────────────────────────────────────────
 
@@ -41,9 +41,9 @@ export async function createCsrfToken() {
   }
 }`,
     variables: null,
-  });
-  csrfToken = data.createCsrfToken.csrfToken;
-  appSessionToken = data.createCsrfToken.appSessionToken;
+  })
+  csrfToken = data.createCsrfToken.csrfToken
+  appSessionToken = data.createCsrfToken.appSessionToken
 }
 
 export async function login(email, password) {
@@ -69,17 +69,17 @@ export async function login(email, password) {
       variables: { email, password },
     },
     { 'Csrf-Token': csrfToken, 'A-Sess': appSessionToken },
-  );
+  )
 
   if (data.login.otpToken) {
-    otpToken = data.login.otpToken;
-    return { mfa: true };
+    otpToken = data.login.otpToken
+    return { mfa: true }
   }
 
-  accessToken = data.login.accessToken;
-  refreshToken = data.login.refreshToken;
-  userSessionToken = data.login.userSessionToken;
-  return { mfa: false };
+  accessToken = data.login.accessToken
+  refreshToken = data.login.refreshToken
+  userSessionToken = data.login.userSessionToken
+  return { mfa: false }
 }
 
 export async function validateOtp(email, otpCode) {
@@ -101,12 +101,12 @@ export async function validateOtp(email, otpCode) {
       variables: { email, otpCode, otpToken },
     },
     { 'Csrf-Token': csrfToken, 'A-Sess': appSessionToken },
-  );
+  )
 
-  accessToken = data.loginWithOTP.accessToken;
-  refreshToken = data.loginWithOTP.refreshToken;
-  userSessionToken = data.loginWithOTP.userSessionToken;
-  otpToken = '';
+  accessToken = data.loginWithOTP.accessToken
+  refreshToken = data.loginWithOTP.refreshToken
+  userSessionToken = data.loginWithOTP.userSessionToken
+  otpToken = ''
 }
 
 // ── Read-only queries ───────────────────────────────────────────────
@@ -151,16 +151,14 @@ export async function getUserInfo() {
   }
 }`,
     variables: null,
-  };
+  }
 
-  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).currentUser;
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).currentUser
 }
 
 export async function getVehicleState(vehicleId, properties) {
-  const props = properties || DEFAULT_VEHICLE_STATE_PROPERTIES;
-  const fragment = [...props]
-    .map((p) => `${p} ${TEMPLATE_MAP[p] || VALUE_TEMPLATE}`)
-    .join('\n    ');
+  const props = properties || DEFAULT_VEHICLE_STATE_PROPERTIES
+  const fragment = [...props].map((p) => `${p} ${TEMPLATE_MAP[p] || VALUE_TEMPLATE}`).join('\n    ')
 
   const body = {
     operationName: 'GetVehicleState',
@@ -170,9 +168,9 @@ export async function getVehicleState(vehicleId, properties) {
   }
 }`,
     variables: { vehicleID: vehicleId },
-  };
+  }
 
-  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).vehicleState;
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).vehicleState
 }
 
 export async function getOTAUpdateDetails(vehicleId) {
@@ -185,9 +183,9 @@ export async function getOTAUpdateDetails(vehicleId) {
   }
 }`,
     variables: { vehicleId },
-  };
+  }
 
-  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle;
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle
 }
 
 export async function getLiveChargingSession(vehicleId) {
@@ -216,9 +214,9 @@ export async function getLiveChargingSession(vehicleId) {
   }
 }`,
     variables: { vehicleId },
-  };
+  }
 
-  return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getLiveSessionData;
+  return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getLiveSessionData
 }
 
 export async function getChargingHistory() {
@@ -244,9 +242,9 @@ export async function getChargingHistory() {
   }
 }`,
     variables: {},
-  };
+  }
 
-  return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getCompletedSessionSummaries;
+  return (await gql(GRAPHQL_CHARGING, body, chargingHeaders())).getCompletedSessionSummaries
 }
 
 export async function getChargingSchedule(vehicleId) {
@@ -265,9 +263,9 @@ export async function getChargingSchedule(vehicleId) {
   }
 }`,
     variables: { vehicleId },
-  };
+  }
 
-  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle;
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle
 }
 
 export async function getDriversAndKeys(vehicleId) {
@@ -291,9 +289,9 @@ export async function getDriversAndKeys(vehicleId) {
   }
 }`,
     variables: { vehicleId },
-  };
+  }
 
-  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle;
+  return (await gql(GRAPHQL_GATEWAY, body, authHeaders())).getVehicle
 }
 
 // ── Session persistence ──────────────────────────────────────────────
@@ -308,26 +306,26 @@ export function exportSession() {
     otpToken,
     needsOtp: !!otpToken,
     authenticated: !!accessToken,
-  };
+  }
 }
 
 export function restoreSession(session) {
-  csrfToken = session.csrfToken || '';
-  appSessionToken = session.appSessionToken || '';
-  accessToken = session.accessToken || '';
-  refreshToken = session.refreshToken || '';
-  userSessionToken = session.userSessionToken || '';
-  otpToken = session.otpToken || '';
+  csrfToken = session.csrfToken || ''
+  appSessionToken = session.appSessionToken || ''
+  accessToken = session.accessToken || ''
+  refreshToken = session.refreshToken || ''
+  userSessionToken = session.userSessionToken || ''
+  otpToken = session.otpToken || ''
 }
 
 // ── Internals ───────────────────────────────────────────────────────
 
 function authHeaders() {
-  return { 'A-Sess': appSessionToken, 'U-Sess': userSessionToken };
+  return { 'A-Sess': appSessionToken, 'U-Sess': userSessionToken }
 }
 
 function chargingHeaders() {
-  return { 'U-Sess': userSessionToken };
+  return { 'U-Sess': userSessionToken }
 }
 
 async function gql(url, body, extraHeaders = {}) {
@@ -339,35 +337,35 @@ async function gql(url, body, extraHeaders = {}) {
       ...extraHeaders,
     },
     body: JSON.stringify(body),
-  });
+  })
 
-  const json = await res.json();
+  const json = await res.json()
 
   if (json.errors?.length) {
-    const e = json.errors[0];
-    const msg = e.message || e.extensions?.code || 'Unknown GraphQL error';
-    const err = new Error(msg);
-    err.code = e.extensions?.code;
-    err.reason = e.extensions?.reason;
-    throw err;
+    const e = json.errors[0]
+    const msg = e.message || e.extensions?.code || 'Unknown GraphQL error'
+    const err = new Error(msg)
+    err.code = e.extensions?.code
+    err.reason = e.extensions?.reason
+    throw err
   }
 
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
+    throw new Error(`HTTP ${res.status}`)
   }
 
-  return json.data;
+  return json.data
 }
 
 // ── Vehicle state property templates ────────────────────────────────
 
-const VALUE_TEMPLATE = '{ timeStamp value }';
+const VALUE_TEMPLATE = '{ timeStamp value }'
 
 const TEMPLATE_MAP = {
   cloudConnection: '{ lastSync isOnline }',
   gnssLocation: '{ latitude longitude timeStamp isAuthorized }',
   gnssError: '{ timeStamp positionVertical positionHorizontal speed bearing }',
-};
+}
 
 const DEFAULT_VEHICLE_STATE_PROPERTIES = new Set([
   'cloudConnection',
@@ -425,4 +423,4 @@ const DEFAULT_VEHICLE_STATE_PROPERTIES = new Set([
   'gearGuardVideoStatus',
   'timeToEndOfCharge',
   'remoteChargingAvailable',
-]);
+])

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,477 +1,492 @@
 #!/usr/bin/env node
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
-import * as rivian from './lib/rivian.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import * as rivian from './lib/rivian.js'
 
-const CONFIG_DIR = join(homedir(), '.rivian-mcp');
-const SESSION_FILE = join(CONFIG_DIR, 'session.json');
-const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const CONFIG_DIR = join(homedir(), '.rivian-mcp')
+const SESSION_FILE = join(CONFIG_DIR, 'session.json')
+const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
 // ── Session persistence ───────────────────────────────────────────────
 
 function loadSession() {
-  if (!existsSync(SESSION_FILE)) return false;
+  if (!existsSync(SESSION_FILE)) return false
 
   try {
-    const st = statSync(SESSION_FILE);
+    const st = statSync(SESSION_FILE)
     if (st.mode & 0o077) {
       console.error(
         `[rivian-mcp] WARNING: ${SESSION_FILE} is readable by other users. Run: chmod 600 "${SESSION_FILE}"`,
-      );
+      )
     }
   } catch {}
 
-  const session = JSON.parse(readFileSync(SESSION_FILE, 'utf8'));
+  const session = JSON.parse(readFileSync(SESSION_FILE, 'utf8'))
 
   if (session.savedAt && Date.now() - session.savedAt > SESSION_MAX_AGE_MS) {
-    console.error('[rivian-mcp] Session expired. Please log in again.');
-    return false;
+    console.error('[rivian-mcp] Session expired. Please log in again.')
+    return false
   }
 
   if (session.authenticated || session.needsOtp) {
-    rivian.restoreSession(session);
-    return session.authenticated ? true : 'needs_otp';
+    rivian.restoreSession(session)
+    return session.authenticated ? true : 'needs_otp'
   }
 
-  return false;
+  return false
 }
 
 function saveSession() {
-  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
-  chmodSync(CONFIG_DIR, 0o700);
-  const session = { ...rivian.exportSession(), savedAt: Date.now() };
-  writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2), { mode: 0o600 });
-  chmodSync(SESSION_FILE, 0o600);
+  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+  chmodSync(CONFIG_DIR, 0o700)
+  const session = { ...rivian.exportSession(), savedAt: Date.now() }
+  writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2), { mode: 0o600 })
+  chmodSync(SESSION_FILE, 0o600)
 }
 
 function requireAuth() {
   if (!rivian.isAuthenticated()) {
-    throw new Error('Not logged in. Ask the user to log in to Rivian first.');
+    throw new Error('Not logged in. Ask the user to log in to Rivian first.')
   }
 }
 
 function text(str) {
-  return { content: [{ type: 'text', text: str }] };
+  return { content: [{ type: 'text', text: str }] }
 }
 
 // ── Formatting ────────────────────────────────────────────────────────
 
 function formatUserInfo(user) {
-  const lines = [`${user.firstName} ${user.lastName} (${user.email})`, ''];
+  const lines = [`${user.firstName} ${user.lastName} (${user.email})`, '']
 
   if (!user.vehicles?.length) {
-    lines.push('No vehicles on this account.');
-    return lines.join('\n');
+    lines.push('No vehicles on this account.')
+    return lines.join('\n')
   }
 
   for (const v of user.vehicles) {
-    const car = v.vehicle;
-    lines.push(v.name || car.model);
-    lines.push(`  ${car.modelYear} ${car.make} ${car.model}`);
-    lines.push(`  VIN: ${v.vin}`);
+    const car = v.vehicle
+    lines.push(v.name || car.model)
+    lines.push(`  ${car.modelYear} ${car.make} ${car.model}`)
+    lines.push(`  VIN: ${v.vin}`)
 
     if (car.otaEarlyAccessStatus) {
-      lines.push(`  OTA early access: ${car.otaEarlyAccessStatus === 'OPTED_IN' ? 'Yes' : 'No'}`);
+      lines.push(`  OTA early access: ${car.otaEarlyAccessStatus === 'OPTED_IN' ? 'Yes' : 'No'}`)
     }
     if (car.currentOTAUpdateDetails) {
-      lines.push(`  Software: v${car.currentOTAUpdateDetails.version}`);
+      lines.push(`  Software: v${car.currentOTAUpdateDetails.version}`)
     }
     if (car.availableOTAUpdateDetails) {
-      lines.push(`  Update available: v${car.availableOTAUpdateDetails.version}`);
-      lines.push(`  Release notes: ${car.availableOTAUpdateDetails.url}`);
+      lines.push(`  Update available: v${car.availableOTAUpdateDetails.version}`)
+      lines.push(`  Release notes: ${car.availableOTAUpdateDetails.url}`)
     } else {
-      lines.push('  Software is up to date');
+      lines.push('  Software is up to date')
     }
-    lines.push('');
+    lines.push('')
   }
 
-  return lines.join('\n').trim();
+  return lines.join('\n').trim()
 }
 
 function formatVehicleState(state) {
-  const lines = [];
-  const printed = new Set();
+  const lines = []
+  const printed = new Set()
 
   function v(key) {
-    return state[key]?.value ?? null;
+    return state[key]?.value ?? null
   }
 
   function print(label, key, suffix = '') {
-    if (!(key in state)) return;
-    printed.add(key);
-    const value = v(key);
-    if (value === null || value === undefined) return;
-    lines.push(`  ${label}: ${value}${suffix}`);
+    if (!(key in state)) return
+    printed.add(key)
+    const value = v(key)
+    if (value === null || value === undefined) return
+    lines.push(`  ${label}: ${value}${suffix}`)
   }
 
   // Battery & Range
   if ('batteryLevel' in state || 'distanceToEmpty' in state) {
-    lines.push('Battery & Range');
-    print('Battery', 'batteryLevel', '%');
-    print('Charge limit', 'batteryLimit', '%');
-    print('Capacity', 'batteryCapacity');
-    print('Range', 'distanceToEmpty', ' miles');
-    print('Odometer', 'vehicleMileage', ' miles');
-    print('Power', 'powerState');
-    print('Time to full', 'timeToEndOfCharge', ' min');
-    print('Remote charging', 'remoteChargingAvailable');
-    lines.push('');
+    lines.push('Battery & Range')
+    print('Battery', 'batteryLevel', '%')
+    print('Charge limit', 'batteryLimit', '%')
+    print('Capacity', 'batteryCapacity')
+    print('Range', 'distanceToEmpty', ' miles')
+    print('Odometer', 'vehicleMileage', ' miles')
+    print('Power', 'powerState')
+    print('Time to full', 'timeToEndOfCharge', ' min')
+    print('Remote charging', 'remoteChargingAvailable')
+    lines.push('')
   }
 
   // Charging
   if ('chargerStatus' in state || 'chargerState' in state) {
-    lines.push('Charging');
-    print('Charger status', 'chargerStatus');
-    print('Charger state', 'chargerState');
-    print('Charge port', 'chargePortState');
-    lines.push('');
+    lines.push('Charging')
+    print('Charger status', 'chargerStatus')
+    print('Charger state', 'chargerState')
+    print('Charge port', 'chargePortState')
+    lines.push('')
   }
 
   // Doors — combine closed + locked per door
-  const doorPositions = ['FrontLeft', 'FrontRight', 'RearLeft', 'RearRight'];
-  const doorLines = [];
+  const doorPositions = ['FrontLeft', 'FrontRight', 'RearLeft', 'RearRight']
+  const doorLines = []
   for (const pos of doorPositions) {
-    const closedKey = `door${pos}Closed`;
-    const lockedKey = `door${pos}Locked`;
+    const closedKey = `door${pos}Closed`
+    const lockedKey = `door${pos}Locked`
     if (closedKey in state || lockedKey in state) {
-      printed.add(closedKey);
-      printed.add(lockedKey);
-      const parts = [v(closedKey), v(lockedKey)].filter(Boolean);
-      const label = pos.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
-      if (parts.length) doorLines.push(`  ${label}: ${parts.join(', ')}`);
+      printed.add(closedKey)
+      printed.add(lockedKey)
+      const parts = [v(closedKey), v(lockedKey)].filter(Boolean)
+      const label = pos
+        .replace(/([A-Z])/g, ' $1')
+        .trim()
+        .toLowerCase()
+      if (parts.length) doorLines.push(`  ${label}: ${parts.join(', ')}`)
     }
   }
   if (doorLines.length) {
-    lines.push('Doors');
-    lines.push(...doorLines);
-    lines.push('');
+    lines.push('Doors')
+    lines.push(...doorLines)
+    lines.push('')
   }
 
   // Closures — frunk, liftgate, tailgate, tonneau
-  const closures = ['Frunk', 'Liftgate', 'Tailgate', 'Tonneau'];
-  const closureLines = [];
+  const closures = ['Frunk', 'Liftgate', 'Tailgate', 'Tonneau']
+  const closureLines = []
   for (const name of closures) {
-    const closedKey = `closure${name}Closed`;
-    const lockedKey = `closure${name}Locked`;
+    const closedKey = `closure${name}Closed`
+    const lockedKey = `closure${name}Locked`
     if (closedKey in state || lockedKey in state) {
-      printed.add(closedKey);
-      printed.add(lockedKey);
-      const parts = [v(closedKey), v(lockedKey)].filter(Boolean);
-      if (parts.length) closureLines.push(`  ${name.toLowerCase()}: ${parts.join(', ')}`);
+      printed.add(closedKey)
+      printed.add(lockedKey)
+      const parts = [v(closedKey), v(lockedKey)].filter(Boolean)
+      if (parts.length) closureLines.push(`  ${name.toLowerCase()}: ${parts.join(', ')}`)
     }
   }
   if (closureLines.length) {
-    lines.push('Closures');
-    lines.push(...closureLines);
-    lines.push('');
+    lines.push('Closures')
+    lines.push(...closureLines)
+    lines.push('')
   }
 
   // Windows
-  const windowLines = [];
+  const windowLines = []
   for (const pos of doorPositions) {
-    const key = `window${pos}Closed`;
+    const key = `window${pos}Closed`
     if (key in state) {
-      printed.add(key);
-      const value = v(key);
+      printed.add(key)
+      const value = v(key)
       if (value) {
-        const label = pos.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
-        windowLines.push(`  ${label}: ${value}`);
+        const label = pos
+          .replace(/([A-Z])/g, ' $1')
+          .trim()
+          .toLowerCase()
+        windowLines.push(`  ${label}: ${value}`)
       }
     }
   }
   if (windowLines.length) {
-    lines.push('Windows');
-    lines.push(...windowLines);
-    lines.push('');
+    lines.push('Windows')
+    lines.push(...windowLines)
+    lines.push('')
   }
 
   // Climate
   if ('cabinClimateInteriorTemperature' in state || 'cabinPreconditioningStatus' in state) {
-    lines.push('Climate');
+    lines.push('Climate')
     if ('cabinClimateInteriorTemperature' in state) {
-      printed.add('cabinClimateInteriorTemperature');
-      const temp = v('cabinClimateInteriorTemperature');
-      if (temp) lines.push(`  Cabin temp: ${temp}°`);
+      printed.add('cabinClimateInteriorTemperature')
+      const temp = v('cabinClimateInteriorTemperature')
+      if (temp) lines.push(`  Cabin temp: ${temp}°`)
     }
-    print('Preconditioning', 'cabinPreconditioningStatus');
-    print('Defrost/defog', 'defrostDefogStatus');
-    print('Pet mode', 'petModeStatus');
-    lines.push('');
+    print('Preconditioning', 'cabinPreconditioningStatus')
+    print('Defrost/defog', 'defrostDefogStatus')
+    print('Pet mode', 'petModeStatus')
+    lines.push('')
   }
 
   // Tires
-  const tirePositions = { FrontLeft: 'front left', FrontRight: 'front right', RearLeft: 'rear left', RearRight: 'rear right' };
-  const tireLines = [];
+  const tirePositions = {
+    FrontLeft: 'front left',
+    FrontRight: 'front right',
+    RearLeft: 'rear left',
+    RearRight: 'rear right',
+  }
+  const tireLines = []
   for (const [pos, label] of Object.entries(tirePositions)) {
-    const key = `tirePressureStatus${pos}`;
+    const key = `tirePressureStatus${pos}`
     if (key in state) {
-      printed.add(key);
-      const value = v(key);
-      if (value) tireLines.push(`  ${label}: ${value}`);
+      printed.add(key)
+      const value = v(key)
+      if (value) tireLines.push(`  ${label}: ${value}`)
     }
   }
   if (tireLines.length) {
-    lines.push('Tire Pressure');
-    lines.push(...tireLines);
-    lines.push('');
+    lines.push('Tire Pressure')
+    lines.push(...tireLines)
+    lines.push('')
   }
 
   // Software (OTA)
   if ('otaCurrentVersion' in state || 'otaAvailableVersion' in state || 'otaStatus' in state) {
-    lines.push('Software');
-    print('Current version', 'otaCurrentVersion');
-    print('Available update', 'otaAvailableVersion');
-    print('Status', 'otaStatus');
-    print('Install status', 'otaCurrentStatus');
-    print('Install ready', 'otaInstallReady');
-    print('Install progress', 'otaInstallProgress', '%');
-    print('Download progress', 'otaDownloadProgress', '%');
-    print('Install type', 'otaInstallType');
-    print('Current hash', 'otaCurrentVersionGitHash');
-    print('Available hash', 'otaAvailableVersionGitHash');
-    lines.push('');
+    lines.push('Software')
+    print('Current version', 'otaCurrentVersion')
+    print('Available update', 'otaAvailableVersion')
+    print('Status', 'otaStatus')
+    print('Install status', 'otaCurrentStatus')
+    print('Install ready', 'otaInstallReady')
+    print('Install progress', 'otaInstallProgress', '%')
+    print('Download progress', 'otaDownloadProgress', '%')
+    print('Install type', 'otaInstallType')
+    print('Current hash', 'otaCurrentVersionGitHash')
+    print('Available hash', 'otaAvailableVersionGitHash')
+    lines.push('')
   }
 
   // Security
   if ('gearGuardLocked' in state) {
-    lines.push('Security');
-    print('Gear Guard', 'gearGuardLocked');
-    print('Gear Guard video', 'gearGuardVideoStatus');
-    lines.push('');
+    lines.push('Security')
+    print('Gear Guard', 'gearGuardLocked')
+    print('Gear Guard video', 'gearGuardVideoStatus')
+    lines.push('')
   }
 
   // Drive
   if ('driveMode' in state || 'gearStatus' in state) {
-    lines.push('Drive');
-    print('Drive mode', 'driveMode');
-    print('Gear', 'gearStatus');
-    lines.push('');
+    lines.push('Drive')
+    print('Drive mode', 'driveMode')
+    print('Gear', 'gearStatus')
+    lines.push('')
   }
 
   // Connection
   if ('cloudConnection' in state) {
-    printed.add('cloudConnection');
-    const cc = state.cloudConnection;
-    const online = cc?.isOnline ? 'Online' : 'Offline';
-    const sync = cc?.lastSync ? ` (last sync: ${cc.lastSync})` : '';
-    lines.push('Connection');
-    lines.push(`  Status: ${online}${sync}`);
-    lines.push('');
+    printed.add('cloudConnection')
+    const cc = state.cloudConnection
+    const online = cc?.isOnline ? 'Online' : 'Offline'
+    const sync = cc?.lastSync ? ` (last sync: ${cc.lastSync})` : ''
+    lines.push('Connection')
+    lines.push(`  Status: ${online}${sync}`)
+    lines.push('')
   }
 
   // Location
   if ('gnssLocation' in state) {
-    printed.add('gnssLocation');
-    const loc = state.gnssLocation;
+    printed.add('gnssLocation')
+    const loc = state.gnssLocation
     if (loc?.latitude && loc?.longitude) {
-      lines.push('Location');
-      lines.push(`  ${loc.latitude}, ${loc.longitude}`);
-      lines.push('');
+      lines.push('Location')
+      lines.push(`  ${loc.latitude}, ${loc.longitude}`)
+      lines.push('')
     }
   }
 
   // Anything not already printed
-  const remaining = [];
+  const remaining = []
   for (const [key, entry] of Object.entries(state)) {
-    if (printed.has(key)) continue;
-    const value = entry?.value ?? entry;
+    if (printed.has(key)) continue
+    const value = entry?.value ?? entry
     if (value !== null && value !== undefined) {
-      remaining.push(`  ${key}: ${value}`);
+      remaining.push(`  ${key}: ${value}`)
     }
   }
   if (remaining.length) {
-    lines.push('Other');
-    lines.push(...remaining);
+    lines.push('Other')
+    lines.push(...remaining)
   }
 
-  return lines.join('\n').trim();
+  return lines.join('\n').trim()
 }
 
 function formatOTAStatus(ota) {
-  const lines = [];
+  const lines = []
 
   if (ota.currentOTAUpdateDetails) {
-    lines.push(`Current software: v${ota.currentOTAUpdateDetails.version}`);
+    lines.push(`Current software: v${ota.currentOTAUpdateDetails.version}`)
   } else {
-    lines.push('Current software: unknown');
+    lines.push('Current software: unknown')
   }
 
   if (ota.availableOTAUpdateDetails) {
-    lines.push(`Update available: v${ota.availableOTAUpdateDetails.version}`);
+    lines.push(`Update available: v${ota.availableOTAUpdateDetails.version}`)
     if (ota.availableOTAUpdateDetails.url) {
-      lines.push(`Release notes: ${ota.availableOTAUpdateDetails.url}`);
+      lines.push(`Release notes: ${ota.availableOTAUpdateDetails.url}`)
     }
   } else {
-    lines.push('No update available — software is up to date.');
+    lines.push('No update available — software is up to date.')
   }
 
-  return lines.join('\n');
+  return lines.join('\n')
 }
 
 function formatChargingSession(data) {
-  if (!data) return 'No active charging session.';
+  if (!data) return 'No active charging session.'
 
-  const lines = ['Charging Session'];
+  const lines = ['Charging Session']
 
   const add = (label, entry, suffix = '') => {
-    const value = entry?.value;
-    if (value !== undefined && value !== null) lines.push(`  ${label}: ${value}${suffix}`);
-  };
-
-  add('Battery', data.soc, '%');
-  add('Power', data.power, ' kW');
-  add('Range added', data.rangeAddedThisSession, ' miles');
-  add('Energy charged', data.totalChargedEnergy, ' kWh');
-  add('Current', data.current, ' A');
-  if (data.timeElapsed) lines.push(`  Time elapsed: ${data.timeElapsed}`);
-  add('Time remaining', data.timeRemaining, ' min');
-
-  if (data.isRivianCharger) lines.push('  Network: Rivian Adventure Network');
-  if (data.isFreeSession) {
-    lines.push('  Cost: Free');
-  } else if (data.currentPrice) {
-    lines.push(`  Cost so far: ${data.currentCurrency || '$'}${data.currentPrice}`);
+    const value = entry?.value
+    if (value !== undefined && value !== null) lines.push(`  ${label}: ${value}${suffix}`)
   }
 
-  add('Charger state', data.vehicleChargerState);
+  add('Battery', data.soc, '%')
+  add('Power', data.power, ' kW')
+  add('Range added', data.rangeAddedThisSession, ' miles')
+  add('Energy charged', data.totalChargedEnergy, ' kWh')
+  add('Current', data.current, ' A')
+  if (data.timeElapsed) lines.push(`  Time elapsed: ${data.timeElapsed}`)
+  add('Time remaining', data.timeRemaining, ' min')
 
-  return lines.join('\n');
+  if (data.isRivianCharger) lines.push('  Network: Rivian Adventure Network')
+  if (data.isFreeSession) {
+    lines.push('  Cost: Free')
+  } else if (data.currentPrice) {
+    lines.push(`  Cost so far: ${data.currentCurrency || '$'}${data.currentPrice}`)
+  }
+
+  add('Charger state', data.vehicleChargerState)
+
+  return lines.join('\n')
 }
 
 function formatChargingHistory(sessions) {
-  if (!sessions?.length) return 'No charging history found.';
+  if (!sessions?.length) return 'No charging history found.'
 
-  const lines = [`Charging History (${sessions.length} sessions)`, ''];
+  const lines = [`Charging History (${sessions.length} sessions)`, '']
 
   for (const s of sessions) {
-    const start = new Date(s.startInstant);
-    const end = new Date(s.endInstant);
-    const date = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    const startTime = start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-    const endTime = end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-    const durationMs = end - start;
-    const durationMin = Math.round(durationMs / 60000);
-    const hours = Math.floor(durationMin / 60);
-    const mins = durationMin % 60;
-    const duration = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+    const start = new Date(s.startInstant)
+    const end = new Date(s.endInstant)
+    const date = start.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+    const startTime = start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    const endTime = end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    const durationMs = end - start
+    const durationMin = Math.round(durationMs / 60000)
+    const hours = Math.floor(durationMin / 60)
+    const mins = durationMin % 60
+    const duration = hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
 
-    const location = [s.city, s.vendor].filter(Boolean).join(' — ');
-    const chargerLabel = s.isHomeCharger ? 'Home' : s.chargerType || 'Unknown';
+    const location = [s.city, s.vendor].filter(Boolean).join(' — ')
+    const chargerLabel = s.isHomeCharger ? 'Home' : s.chargerType || 'Unknown'
 
-    lines.push(`${date}  ${startTime}–${endTime} (${duration})`);
-    if (location) lines.push(`  Location: ${location}`);
-    lines.push(`  Charger: ${chargerLabel}`);
-    if (s.totalEnergyKwh != null) lines.push(`  Energy: ${s.totalEnergyKwh.toFixed(1)} kWh`);
+    lines.push(`${date}  ${startTime}–${endTime} (${duration})`)
+    if (location) lines.push(`  Location: ${location}`)
+    lines.push(`  Charger: ${chargerLabel}`)
+    if (s.totalEnergyKwh != null) lines.push(`  Energy: ${s.totalEnergyKwh.toFixed(1)} kWh`)
     if (s.rangeAddedKm != null) {
-      const miles = (s.rangeAddedKm * 0.621371).toFixed(0);
-      lines.push(`  Range added: ${miles} miles`);
+      const miles = (s.rangeAddedKm * 0.621371).toFixed(0)
+      lines.push(`  Range added: ${miles} miles`)
     }
     if (s.paidTotal != null && s.paidTotal > 0) {
-      const currency = s.currencyCode === 'USD' ? '$' : `${s.currencyCode} `;
-      lines.push(`  Cost: ${currency}${s.paidTotal.toFixed(2)}`);
+      const currency = s.currencyCode === 'USD' ? '$' : `${s.currencyCode} `
+      lines.push(`  Cost: ${currency}${s.paidTotal.toFixed(2)}`)
     } else if (s.paidTotal === 0) {
-      lines.push('  Cost: Free');
+      lines.push('  Cost: Free')
     }
-    lines.push('');
+    lines.push('')
   }
 
-  return lines.join('\n').trim();
+  return lines.join('\n').trim()
 }
 
 function formatChargingSchedule(data) {
-  const schedules = data?.chargingSchedules;
-  if (!schedules?.length) return 'No charging schedules configured.';
+  const schedules = data?.chargingSchedules
+  if (!schedules?.length) return 'No charging schedules configured.'
 
-  const lines = ['Charging Schedules', ''];
+  const lines = ['Charging Schedules', '']
 
   for (const s of schedules) {
-    const startHour = Math.floor(s.startTime / 60);
-    const startMin = s.startTime % 60;
-    const endMinutes = s.startTime + s.duration;
-    const endHour = Math.floor(endMinutes / 60) % 24;
-    const endMin = endMinutes % 60;
+    const startHour = Math.floor(s.startTime / 60)
+    const startMin = s.startTime % 60
+    const endMinutes = s.startTime + s.duration
+    const endHour = Math.floor(endMinutes / 60) % 24
+    const endMin = endMinutes % 60
 
     const fmt = (h, m) => {
-      const period = h >= 12 ? 'PM' : 'AM';
-      const hour12 = h % 12 || 12;
-      return `${hour12}:${String(m).padStart(2, '0')} ${period}`;
-    };
+      const period = h >= 12 ? 'PM' : 'AM'
+      const hour12 = h % 12 || 12
+      return `${hour12}:${String(m).padStart(2, '0')} ${period}`
+    }
 
-    lines.push(`${fmt(startHour, startMin)} – ${fmt(endHour, endMin)} (${s.duration / 60}h)`);
-    lines.push(`  Amperage: ${s.amperage}A`);
-    lines.push(`  Enabled: ${s.enabled ? 'Yes' : 'No'}`);
-    if (s.weekDays?.length) lines.push(`  Days: ${s.weekDays.join(', ')}`);
-    if (s.location) lines.push(`  Location: ${s.location.latitude}, ${s.location.longitude}`);
-    lines.push('');
+    lines.push(`${fmt(startHour, startMin)} – ${fmt(endHour, endMin)} (${s.duration / 60}h)`)
+    lines.push(`  Amperage: ${s.amperage}A`)
+    lines.push(`  Enabled: ${s.enabled ? 'Yes' : 'No'}`)
+    if (s.weekDays?.length) lines.push(`  Days: ${s.weekDays.join(', ')}`)
+    if (s.location) lines.push(`  Location: ${s.location.latitude}, ${s.location.longitude}`)
+    lines.push('')
   }
 
-  return lines.join('\n').trim();
+  return lines.join('\n').trim()
 }
 
 function formatDriversAndKeys(data) {
-  const lines = [];
+  const lines = []
 
-  if (data.vin) lines.push(`Vehicle: ${data.vin}`);
+  if (data.vin) lines.push(`Vehicle: ${data.vin}`)
 
   if (!data.invitedUsers?.length) {
-    lines.push('No drivers or keys found.');
-    return lines.join('\n');
+    lines.push('No drivers or keys found.')
+    return lines.join('\n')
   }
 
-  lines.push('');
+  lines.push('')
   for (const user of data.invitedUsers) {
     if (user.firstName) {
-      lines.push(`${user.firstName} ${user.lastName} (${user.email})`);
-      if (user.roles?.length) lines.push(`  Roles: ${user.roles.join(', ')}`);
+      lines.push(`${user.firstName} ${user.lastName} (${user.email})`)
+      if (user.roles?.length) lines.push(`  Roles: ${user.roles.join(', ')}`)
 
       if (user.devices?.length) {
         for (const d of user.devices) {
-          const name = d.deviceName || d.type;
+          const name = d.deviceName || d.type
           const status = [
             d.isPaired ? 'paired' : 'not paired',
             d.isEnabled ? 'enabled' : 'disabled',
-          ].join(', ');
-          lines.push(`  ${name} — ${status}`);
+          ].join(', ')
+          lines.push(`  ${name} — ${status}`)
         }
       }
     } else {
-      lines.push(`${user.email} (invited, ${user.status})`);
+      lines.push(`${user.email} (invited, ${user.status})`)
     }
-    lines.push('');
+    lines.push('')
   }
 
-  return lines.join('\n').trim();
+  return lines.join('\n').trim()
 }
 
 // ── Vehicle ID resolution ─────────────────────────────────────────────
 
-let cachedVehicleId = null;
+let cachedVehicleId = null
 
 async function resolveVehicleId() {
-  if (cachedVehicleId) return cachedVehicleId;
-  const user = await rivian.getUserInfo();
+  if (cachedVehicleId) return cachedVehicleId
+  const user = await rivian.getUserInfo()
   if (!user.vehicles?.length) {
-    throw new Error('No vehicles found on your Rivian account.');
+    throw new Error('No vehicles found on your Rivian account.')
   }
-  cachedVehicleId = user.vehicles[0].id;
-  return cachedVehicleId;
+  cachedVehicleId = user.vehicles[0].id
+  return cachedVehicleId
 }
 
 // ── Restore session on startup ────────────────────────────────────────
 
-loadSession();
+loadSession()
 
 // ── MCP Server ────────────────────────────────────────────────────────
 
 const server = new McpServer({
   name: 'rivian',
   version: '1.0.0',
-});
+})
 
 // ── Auth tools ────────────────────────────────────────────────────────
 
@@ -480,57 +495,57 @@ server.tool(
   'Log in to your Rivian account. Rivian will send a verification code to your phone or email — use rivian_submit_otp to complete sign-in.',
   {},
   async () => {
-    const email = process.env.RIVIAN_EMAIL;
-    const password = process.env.RIVIAN_PASSWORD;
+    const email = process.env.RIVIAN_EMAIL
+    const password = process.env.RIVIAN_PASSWORD
     if (!email || !password) {
       return text(
         'Rivian credentials are not configured. Set RIVIAN_EMAIL and RIVIAN_PASSWORD in your MCP server settings.',
-      );
+      )
     }
 
     try {
-      await rivian.createCsrfToken();
-      const { mfa } = await rivian.login(email, password);
-      saveSession();
+      await rivian.createCsrfToken()
+      const { mfa } = await rivian.login(email, password)
+      saveSession()
 
       if (mfa) {
         return text(
           "A verification code has been sent to your phone or email. Tell me the code and I'll complete the sign-in.",
-        );
+        )
       }
 
-      return text('Signed in to Rivian successfully.');
+      return text('Signed in to Rivian successfully.')
     } catch (err) {
-      return text(`Couldn't sign in: ${err.message}`);
+      return text(`Couldn't sign in: ${err.message}`)
     }
   },
-);
+)
 
 server.tool(
   'rivian_submit_otp',
   'Complete Rivian sign-in with the verification code sent to your phone or email.',
   { otp_code: z.string().describe('The verification code') },
   async ({ otp_code }) => {
-    const email = process.env.RIVIAN_EMAIL;
+    const email = process.env.RIVIAN_EMAIL
     if (!email) {
-      return text('RIVIAN_EMAIL is not configured.');
+      return text('RIVIAN_EMAIL is not configured.')
     }
 
     if (!rivian.needsOtp()) {
-      return text('No pending verification. Start with rivian_login first.');
+      return text('No pending verification. Start with rivian_login first.')
     }
 
     try {
-      await rivian.validateOtp(email, otp_code);
-      saveSession();
-      return text('Signed in to Rivian successfully.');
+      await rivian.validateOtp(email, otp_code)
+      saveSession()
+      return text('Signed in to Rivian successfully.')
     } catch (err) {
       return text(
         `Verification failed: ${err.message}. You may need to start over with rivian_login.`,
-      );
+      )
     }
   },
-);
+)
 
 // ── Read-only query tools ─────────────────────────────────────────────
 
@@ -540,13 +555,13 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      return text(formatUserInfo(await rivian.getUserInfo()));
+      requireAuth()
+      return text(formatUserInfo(await rivian.getUserInfo()))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_vehicle_state',
@@ -559,15 +574,15 @@ server.tool(
   },
   async ({ properties }) => {
     try {
-      requireAuth();
-      const vehicleId = await resolveVehicleId();
-      const props = properties ? new Set(properties) : undefined;
-      return text(formatVehicleState(await rivian.getVehicleState(vehicleId, props)));
+      requireAuth()
+      const vehicleId = await resolveVehicleId()
+      const props = properties ? new Set(properties) : undefined
+      return text(formatVehicleState(await rivian.getVehicleState(vehicleId, props)))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_ota_status',
@@ -575,14 +590,14 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      const vehicleId = await resolveVehicleId();
-      return text(formatOTAStatus(await rivian.getOTAUpdateDetails(vehicleId)));
+      requireAuth()
+      const vehicleId = await resolveVehicleId()
+      return text(formatOTAStatus(await rivian.getOTAUpdateDetails(vehicleId)))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_charging_session',
@@ -590,14 +605,14 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      const vehicleId = await resolveVehicleId();
-      return text(formatChargingSession(await rivian.getLiveChargingSession(vehicleId)));
+      requireAuth()
+      const vehicleId = await resolveVehicleId()
+      return text(formatChargingSession(await rivian.getLiveChargingSession(vehicleId)))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_charging_history',
@@ -605,13 +620,13 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      return text(formatChargingHistory(await rivian.getChargingHistory()));
+      requireAuth()
+      return text(formatChargingHistory(await rivian.getChargingHistory()))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_charging_schedule',
@@ -619,14 +634,14 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      const vehicleId = await resolveVehicleId();
-      return text(formatChargingSchedule(await rivian.getChargingSchedule(vehicleId)));
+      requireAuth()
+      const vehicleId = await resolveVehicleId()
+      return text(formatChargingSchedule(await rivian.getChargingSchedule(vehicleId)))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 server.tool(
   'rivian_get_drivers_and_keys',
@@ -634,16 +649,16 @@ server.tool(
   {},
   async () => {
     try {
-      requireAuth();
-      const vehicleId = await resolveVehicleId();
-      return text(formatDriversAndKeys(await rivian.getDriversAndKeys(vehicleId)));
+      requireAuth()
+      const vehicleId = await resolveVehicleId()
+      return text(formatDriversAndKeys(await rivian.getDriversAndKeys(vehicleId)))
     } catch (err) {
-      return text(err.message);
+      return text(err.message)
     }
   },
-);
+)
 
 // ── Start ─────────────────────────────────────────────────────────────
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,14 @@
         "rivian-mcp": "mcp-server.js"
       },
       "devDependencies": {
+        "eslint": "^10.0.2",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.3.0",
+        "prettier": "^3.8.1",
         "semantic-release": "^25.0.3"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {
@@ -107,6 +111,113 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -117,6 +228,58 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -645,6 +808,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -663,6 +847,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -795,6 +1003,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -832,6 +1050,19 @@
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1393,6 +1624,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1689,6 +1927,287 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1848,6 +2367,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -1878,6 +2411,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1956,6 +2502,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2109,6 +2676,32 @@
         "stream-combiner2": "~1.1.1",
         "through2": "~2.0.0",
         "traverse": "0.6.8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -2306,6 +2899,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2356,6 +2959,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -2439,6 +3052,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2447,6 +3070,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -2583,6 +3219,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -2609,6 +3252,13 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.3.tgz",
@@ -2627,6 +3277,30 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -2917,6 +3591,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2944,6 +3634,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -5076,6 +5773,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -5376,6 +6091,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -5417,6 +6158,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -6413,6 +7164,19 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
@@ -6532,6 +7296,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -6589,6 +7363,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -6750,6 +7534,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lib/"
   ],
   "scripts": {
-    "start": "node mcp-server.js"
+    "start": "node mcp-server.js",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "keywords": [
     "rivian",
@@ -45,6 +48,10 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "eslint": "^10.0.2",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.3.0",
+    "prettier": "^3.8.1",
     "semantic-release": "^25.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- Add ESLint (flat config) with Node.js globals, `prefer-const`, `no-var`, `eqeqeq` (with `null: ignore` for the `!= null` idiom)
- Add `eslint-config-prettier` to avoid formatting rule conflicts
- Add Prettier: single quotes, no semicolons, trailing commas, 100-char print width
- Add `lint`, `format`, and `format:check` npm scripts
- Format all source files

## Test plan

- [ ] `npm run lint` passes with no errors
- [ ] `npm run format:check` passes with no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)