### PR TITLE
fix: add Bearer token to charging headers

### DIFF
--- a/lib/rivian.js
+++ b/lib/rivian.js
@@ -322,7 +322,10 @@ function authHeaders() {
 }
 
 function chargingHeaders() {
-  return { 'U-Sess': session.userSessionToken };
+  return {
+    'U-Sess': session.userSessionToken,
+    Authorization: `Bearer ${session.accessToken}`,
+  };
 }
 
 async function gql(url, body, extraHeaders = {}) {

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -355,7 +355,9 @@ function formatChargingSession(data) {
 }
 
 function formatChargingHistory(sessions) {
-  if (!sessions?.length) return 'No charging history found.'
+  if (sessions === null || sessions === undefined)
+    return 'No charging history returned. Your session may have expired — try logging in again.'
+  if (!sessions.length) return 'No charging history found.'
 
   const lines = [`Charging History (${sessions.length} sessions)`, '']
 


### PR DESCRIPTION
## Summary

- Add `Authorization: Bearer <accessToken>` to `chargingHeaders()` — the charging endpoint (`chrg/user/graphql`) is a separate service that requires OAuth Bearer auth, not just the `U-Sess` session header
- The `accessToken` was being stored in session state but never sent in any request headers
- Differentiate `null` (auth/request failure) from `[]` (no sessions) in `formatChargingHistory` to surface a clearer error message instead of silently showing "No charging history found."

## Test plan

- [ ] Reload MCP server and call `rivian_get_charging_history`
- [ ] Verify charging sessions are returned for an authenticated user
- [ ] Verify live charging session still works (also uses `chargingHeaders()`)
- [ ] Verify that a session with missing tokens shows the improved "session may have expired" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)