### PR TITLE
feat: include OTA status and flagged-for-update in OTA tool response

### DIFF
--- a/lib/rivian.js
+++ b/lib/rivian.js
@@ -182,6 +182,9 @@ export async function getOTAUpdateDetails(vehicleId) {
   getVehicle(id: $vehicleId) {
     availableOTAUpdateDetails { url version locale }
     currentOTAUpdateDetails { url version locale }
+    vehicleState {
+      otaStatus { value timeStamp }
+    }
   }
 }`,
     variables: { vehicleId },

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -312,11 +312,18 @@ function formatOTAStatus(ota) {
     lines.push('Current software: unknown')
   }
 
+  const otaStatus = ota.vehicleState?.otaStatus?.value
+  if (otaStatus) {
+    lines.push(`OTA status: ${otaStatus}`)
+  }
+
   if (ota.availableOTAUpdateDetails) {
     lines.push(`Update available: v${ota.availableOTAUpdateDetails.version}`)
     if (ota.availableOTAUpdateDetails.url) {
       lines.push(`Release notes: ${ota.availableOTAUpdateDetails.url}`)
     }
+  } else if (otaStatus && otaStatus.toLowerCase() !== 'idle') {
+    lines.push('Flagged for update — details pending.')
   } else {
     lines.push('No update available — software is up to date.')
   }


### PR DESCRIPTION
## Summary

- Expands the `getOTAUpdateDetails` GraphQL query to also fetch `vehicleState.otaStatus`
- Surfaces the live OTA status value in the formatted tool response
- Handles the "flagged for update" case where a vehicle is queued for an update before `availableOTAUpdateDetails` is populated

## Test plan

- [ ] Verify `rivian_get_ota_status` shows `OTA status: <value>` when the vehicle state has an OTA status
- [ ] Confirm "Flagged for update — details pending." appears when status is non-Idle but no update details are available
- [ ] Confirm "No update available — software is up to date." still appears when status is `Idle` and no update is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)