### PR TITLE
fix: resolve GraphQL validation and parse errors in vehicle state query

### DIFF
--- a/lib/rivian-api.js
+++ b/lib/rivian-api.js
@@ -376,7 +376,7 @@ const VALUE_TEMPLATE = '{ timeStamp value }'
 
 const TEMPLATE_MAP = {
   cloudConnection: '{ lastSync isOnline }',
-  gnssLocation: '{ latitude longitude timeStamp isAuthorized }',
+  gnssLocation: '{ latitude longitude timeStamp }',
   gnssError: '{ timeStamp positionVertical positionHorizontal speed bearing }',
 }
 

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -151,7 +151,7 @@ server.tool(
     try {
       requireAuth()
       const vehicleId = await resolveVehicleId()
-      const props = properties ? new Set(properties) : undefined
+      const props = properties?.length ? new Set(properties) : undefined
       return text(format.formatVehicleState(await rivian.getVehicleState(vehicleId, props)))
     } catch (err) {
       return text(err.message)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "start": "node mcp-server.js",
+    "test": "node --test",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/test/vehicle-state.test.js
+++ b/test/vehicle-state.test.js
@@ -1,0 +1,92 @@
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { getVehicleState } from '../lib/rivian-api.js'
+
+// ── Mock fetch ────────────────────────────────────────────────────────
+
+let capturedQuery = null
+
+beforeEach(() => {
+  capturedQuery = null
+  globalThis.fetch = async (_url, options) => {
+    capturedQuery = JSON.parse(options.body).query
+    return {
+      ok: true,
+      json: async () => ({ data: { vehicleState: {} } }),
+    }
+  }
+})
+
+// ── gnssLocation template ─────────────────────────────────────────────
+
+test('gnssLocation does not include isAuthorized', async () => {
+  await getVehicleState('test-id')
+  assert.match(capturedQuery, /gnssLocation \{ latitude longitude timeStamp \}/)
+  assert.doesNotMatch(capturedQuery, /isAuthorized/)
+})
+
+// ── OTA fields ────────────────────────────────────────────────────────
+
+test('OTA fields use { timeStamp value } sub-selection', async () => {
+  await getVehicleState('test-id')
+  for (const field of [
+    'otaCurrentVersion',
+    'otaAvailableVersion',
+    'otaStatus',
+    'otaInstallReady',
+    'otaInstallProgress',
+    'otaCurrentStatus',
+    'otaDownloadProgress',
+    'otaInstallType',
+  ]) {
+    assert.match(
+      capturedQuery,
+      new RegExp(`${field} \\{ timeStamp value \\}`),
+      `${field} should use { timeStamp value }`,
+    )
+  }
+})
+
+// ── Custom properties ─────────────────────────────────────────────────
+
+test('custom properties generate correct fragment', async () => {
+  await getVehicleState('test-id', new Set(['batteryLevel', 'powerState']))
+  assert.match(capturedQuery, /batteryLevel \{ timeStamp value \}/)
+  assert.match(capturedQuery, /powerState \{ timeStamp value \}/)
+  assert.doesNotMatch(capturedQuery, /gnssLocation/)
+  assert.doesNotMatch(capturedQuery, /otaStatus/)
+})
+
+test('cloudConnection uses its custom template', async () => {
+  await getVehicleState('test-id', new Set(['cloudConnection']))
+  assert.match(capturedQuery, /cloudConnection \{ lastSync isOnline \}/)
+})
+
+// ── Empty / undefined properties → default set ────────────────────────
+
+test('undefined properties falls back to default set', async () => {
+  await getVehicleState('test-id', undefined)
+  // Spot-check a few default fields
+  assert.match(capturedQuery, /batteryLevel \{ timeStamp value \}/)
+  assert.match(capturedQuery, /gnssLocation/)
+  assert.match(capturedQuery, /otaStatus/)
+})
+
+// ── props resolution (mcp-server.js logic) ────────────────────────────
+
+test('empty properties array resolves to undefined (uses defaults)', () => {
+  const resolve = (properties) => (properties?.length ? new Set(properties) : undefined)
+  assert.equal(resolve([]), undefined, '[] should resolve to undefined')
+  assert.equal(resolve(undefined), undefined, 'undefined should resolve to undefined')
+  const result = resolve(['batteryLevel'])
+  assert.ok(result instanceof Set)
+  assert.equal(result.size, 1)
+})
+
+// ── Query structure ───────────────────────────────────────────────────
+
+test('query uses correct operation name and variable', async () => {
+  await getVehicleState('test-id')
+  assert.match(capturedQuery, /query GetVehicleState\(\$vehicleID: String!\)/)
+  assert.match(capturedQuery, /vehicleState\(id: \$vehicleID\)/)
+})


### PR DESCRIPTION
## Summary

- Remove `isAuthorized` from the `gnssLocation` template — this field causes `GRAPHQL_VALIDATION_FAILED` at line 4, col 49 on the live Rivian API (reported error in #6). The bretterer/rivian-python-client schema reference includes it, but the actual API rejects it.
- Treat an empty `properties: []` array the same as no argument — an empty array produced an empty GraphQL selection set (`vehicleState(id: $vehicleID) {}`), which is invalid GraphQL and caused a parse error.

## Changes

- `lib/rivian-api.js`: Remove `isAuthorized` from `gnssLocation` TEMPLATE_MAP entry
- `mcp-server.js`: Use `properties?.length` check instead of `properties` to treat `[]` as "use defaults"

## Testing

- [ ] `npx rivian-mcp stats` returns vehicle state without errors
- [ ] `rivian_get_vehicle_state` with no properties returns full status report
- [ ] `rivian_get_vehicle_state` with `properties: []` returns full status report (uses defaults)
- [ ] `rivian_get_vehicle_state` with specific OTA properties returns results without validation errors

Fixes #6