### PR TITLE
docs: add Claude Code plugin install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Read-only [MCP server](https://modelcontextprotocol.io) and CLI for Rivian's und
 
 **Strictly read-only** — no vehicle commands, no settings changes.
 
+## Install as Claude Code Plugin
+
+Install the skill so Claude automatically knows how to work with this codebase and the Rivian API:
+
+```bash
+claude /install-plugin https://github.com/PatrickHeneise/rivian-mcp
+```
+
+The skill loads context about the Rivian GraphQL API, confirmed vehicle state properties, auth flow, and formatter patterns whenever you're working on this project.
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
Plugin install section was dropped in the squash merge. Re-adding it.

```bash
claude /install-plugin https://github.com/PatrickHeneise/rivian-mcp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)