### PR TITLE
fix: correct marketplace.json source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "rivian-mcp",
       "description": "Skills for working with the Rivian MCP server — vehicle state, charging, OTA updates, and the unofficial Rivian GraphQL API.",
       "category": "development",
-      "source": ".",
+      "source": "./",
       "homepage": "https://github.com/PatrickHeneise/rivian-mcp"
     }
   ]


### PR DESCRIPTION
Schema requires `"./"` not `"."` — was causing "Invalid input" on plugin install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)