### PR TITLE
fix: correct marketplace schema format and install instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,8 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "zentered",
-  "description": "Claude Code plugins by Zentered — a software and AI consultancy.",
+  "name": "rivian-ai",
+  "metadata": {
+    "description": "Rivian AI tools and skills for Claude Code"
+  },
   "owner": {
     "name": "Zentered",
     "email": "hi@zentered.co"
@@ -10,9 +11,12 @@
     {
       "name": "rivian-mcp",
       "description": "Skills for working with the Rivian MCP server — vehicle state, charging, OTA updates, and the unofficial Rivian GraphQL API.",
-      "category": "development",
+      "version": "1.0.0",
       "source": "./",
-      "homepage": "https://github.com/PatrickHeneise/rivian-mcp"
+      "author": {
+        "name": "Patrick Heneise",
+        "email": "hi@zentered.co"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -6,13 +6,26 @@ Read-only [MCP server](https://modelcontextprotocol.io) and CLI for Rivian's und
 
 ## Install as Claude Code Plugin
 
-Install the skill so Claude automatically knows how to work with this codebase and the Rivian API:
+Install the skill so Claude automatically knows how to work with this codebase and the Rivian API — confirmed vehicle state properties, auth flow, formatter patterns, and what fields don't exist.
+
+**From the terminal:**
 
 ```bash
-claude /install-plugin https://github.com/PatrickHeneise/rivian-mcp
+claude /plugin marketplace add PatrickHeneise/rivian-mcp
+claude /plugin install rivian-mcp@rivian-ai
 ```
 
-The skill loads context about the Rivian GraphQL API, confirmed vehicle state properties, auth flow, and formatter patterns whenever you're working on this project.
+**Inside Claude Code**, type:
+
+```
+/plugin marketplace add PatrickHeneise/rivian-mcp
+```
+
+Then:
+
+```
+/plugin install rivian-mcp@rivian-ai
+```
 
 ## Setup
 


### PR DESCRIPTION
Fixes two issues:

1. `marketplace.json` — updated to match correct schema format (name/metadata/version/author fields), renamed marketplace from `zentered` to `rivian-ai`
2. README — replaced broken `/install-plugin` with correct `/plugin marketplace add` + `/plugin install rivian-mcp@rivian-ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)