### PR TITLE
fix: use refresh token on session expiry and handle SIGINT in CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,6 +54,15 @@ async function ensureAuth() {
   const result = loadSession(rivian)
   if (result === true) return
 
+  if (result === 'expired') {
+    const refreshed = await rivian.refreshSession()
+    if (refreshed) {
+      saveSession(rivian)
+      return
+    }
+    // refresh failed — fall through to full re-auth
+  }
+
   // OTP was already initiated (e.g. via MCP login) — just complete it
   if (result === 'needs_otp') {
     const email = process.env.RIVIAN_EMAIL || (await prompt(`${c.dim('Rivian email:')} `))
@@ -85,6 +94,8 @@ async function resolveVehicleId() {
   if (!user.vehicles?.length) throw new Error('No vehicles found on your Rivian account.')
   return user.vehicles[0].id
 }
+
+process.on('SIGINT', () => process.exit(130))
 
 const command = process.argv[2]
 

--- a/lib/rivian-api.js
+++ b/lib/rivian-api.js
@@ -84,6 +84,35 @@ export async function login(email, password) {
   return { mfa: false }
 }
 
+export async function refreshSession() {
+  if (!session.refreshToken || !session.appSessionToken) return false
+  try {
+    const data = await gql(
+      GRAPHQL_GATEWAY,
+      {
+        operationName: 'RefreshSessionTokens',
+        query: `mutation RefreshSessionTokens($appSessionToken: String!, $refreshToken: String!) {
+  refreshSessionTokens(input: { appSessionToken: $appSessionToken, refreshToken: $refreshToken }) {
+    __typename
+    accessToken
+    refreshToken
+    userSessionToken
+  }
+}`,
+        variables: { appSessionToken: session.appSessionToken, refreshToken: session.refreshToken },
+      },
+      { 'Csrf-Token': session.csrfToken, 'A-Sess': session.appSessionToken },
+    )
+    if (!data?.refreshSessionTokens?.accessToken) return false
+    session.accessToken = data.refreshSessionTokens.accessToken
+    session.refreshToken = data.refreshSessionTokens.refreshToken
+    session.userSessionToken = data.refreshSessionTokens.userSessionToken
+    return true
+  } catch {
+    return false
+  }
+}
+
 export async function validateOtp(email, otpCode) {
   const data = await gql(
     GRAPHQL_GATEWAY,

--- a/lib/session.js
+++ b/lib/session.js
@@ -30,8 +30,8 @@ export function loadSession(rivianApi) {
   }
 
   if (session.savedAt && Date.now() - session.savedAt > SESSION_MAX_AGE_MS) {
-    console.error('[rivian-mcp] Session expired. Please log in again.')
-    return false
+    rivianApi.restoreSession(session)
+    return 'expired'
   }
 
   if (session.authenticated || session.needsOtp) {

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -51,7 +51,12 @@ async function resolveVehicleId() {
 // ── Restore session on startup ────────────────────────────────────────
 
 try {
-  loadSession(rivian)
+  const sessionResult = loadSession(rivian)
+  if (sessionResult === 'expired') {
+    rivian.refreshSession().then((ok) => {
+      if (ok) saveSession(rivian)
+    }).catch(() => {})
+  }
 } catch (err) {
   console.error(`[rivian-mcp] Failed to restore session, starting unauthenticated: ${err.message}`)
 }


### PR DESCRIPTION
## Summary

- Adds `refreshSession()` to `rivian-api.js` — attempts `RefreshSessionTokens` mutation with stored `appSessionToken` + `refreshToken` instead of forcing full re-login when the 7-day session window expires
- `loadSession()` now returns `'expired'` (instead of logging an error and returning `false`), restoring tokens into memory so the refresh attempt has what it needs
- Both CLI (`ensureAuth`) and MCP server startup attempt the token refresh; on failure, fall through silently to full re-auth
- Adds `process.on('SIGINT', () => process.exit(130))` to CLI to prevent the `Warning: Detected unsettled top-level await` message when pressing Ctrl-C during a prompt

## Test plan

- [ ] Let a session expire (or manually set `savedAt` to 8 days ago in `~/.rivian-mcp/session.json`) and verify `rivian ota` refreshes silently without prompting
- [ ] If refresh fails (e.g. invalidate the refresh token), verify it falls through to the email/password prompt
- [ ] Press Ctrl-C during the `Rivian email:` prompt — confirm no warning is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)