### PR TITLE
fix: log token refresh error for diagnostics

### DIFF
--- a/lib/rivian-api.js
+++ b/lib/rivian-api.js
@@ -108,7 +108,8 @@ export async function refreshSession() {
     session.refreshToken = data.refreshSessionTokens.refreshToken
     session.userSessionToken = data.refreshSessionTokens.userSessionToken
     return true
-  } catch {
+  } catch (err) {
+    console.error(`[rivian-mcp] Token refresh failed: ${err.message}`)
     return false
   }
 }


### PR DESCRIPTION
Surface the API error from `refreshSession()` so we can diagnose why the refresh is failing instead of swallowing it silently.