### PR TITLE
fix: extend session window to 90 days, remove non-existent refresh mutation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,15 +54,6 @@ async function ensureAuth() {
   const result = loadSession(rivian)
   if (result === true) return
 
-  if (result === 'expired') {
-    const refreshed = await rivian.refreshSession()
-    if (refreshed) {
-      saveSession(rivian)
-      return
-    }
-    // refresh failed — fall through to full re-auth
-  }
-
   // OTP was already initiated (e.g. via MCP login) — just complete it
   if (result === 'needs_otp') {
     const email = process.env.RIVIAN_EMAIL || (await prompt(`${c.dim('Rivian email:')} `))

--- a/lib/rivian-api.js
+++ b/lib/rivian-api.js
@@ -84,35 +84,6 @@ export async function login(email, password) {
   return { mfa: false }
 }
 
-export async function refreshSession() {
-  if (!session.refreshToken || !session.appSessionToken) return false
-  try {
-    const data = await gql(
-      GRAPHQL_GATEWAY,
-      {
-        operationName: 'RefreshSessionTokens',
-        query: `mutation RefreshSessionTokens($appSessionToken: String!, $refreshToken: String!) {
-  refreshSessionTokens(input: { appSessionToken: $appSessionToken, refreshToken: $refreshToken }) {
-    __typename
-    accessToken
-    refreshToken
-    userSessionToken
-  }
-}`,
-        variables: { appSessionToken: session.appSessionToken, refreshToken: session.refreshToken },
-      },
-      { 'Csrf-Token': session.csrfToken, 'A-Sess': session.appSessionToken },
-    )
-    if (!data?.refreshSessionTokens?.accessToken) return false
-    session.accessToken = data.refreshSessionTokens.accessToken
-    session.refreshToken = data.refreshSessionTokens.refreshToken
-    session.userSessionToken = data.refreshSessionTokens.userSessionToken
-    return true
-  } catch (err) {
-    console.error(`[rivian-mcp] Token refresh failed: ${err.message}`)
-    return false
-  }
-}
 
 export async function validateOtp(email, otpCode) {
   const data = await gql(

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,7 +4,7 @@ import { homedir } from 'node:os'
 
 export const CONFIG_DIR = join(homedir(), '.rivian-mcp')
 export const SESSION_FILE = join(CONFIG_DIR, 'session.json')
-const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const SESSION_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000
 
 export function loadSession(rivianApi) {
   if (!existsSync(SESSION_FILE)) return false
@@ -30,8 +30,8 @@ export function loadSession(rivianApi) {
   }
 
   if (session.savedAt && Date.now() - session.savedAt > SESSION_MAX_AGE_MS) {
-    rivianApi.restoreSession(session)
-    return 'expired'
+    console.error('[rivian-mcp] Session expired. Please log in again.')
+    return false
   }
 
   if (session.authenticated || session.needsOtp) {

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -51,12 +51,7 @@ async function resolveVehicleId() {
 // ── Restore session on startup ────────────────────────────────────────
 
 try {
-  const sessionResult = loadSession(rivian)
-  if (sessionResult === 'expired') {
-    rivian.refreshSession().then((ok) => {
-      if (ok) saveSession(rivian)
-    }).catch(() => {})
-  }
+  loadSession(rivian)
 } catch (err) {
   console.error(`[rivian-mcp] Failed to restore session, starting unauthenticated: ${err.message}`)
 }


### PR DESCRIPTION
## Summary

- The Rivian API returns `GRAPHQL_VALIDATION_FAILED` for `refreshSessionTokens` — the mutation does not exist
- Removes `refreshSession()` and all callers (CLI + MCP server)
- Extends the local session expiry from 7 to 90 days — the 7-day limit was causing forced re-logins even when the actual Rivian tokens were still valid

## Test plan

- [ ] Log in once, wait more than 7 days, verify `rivian ota` still works without prompting
- [ ] After 90 days (or manually set `savedAt` to 91 days ago) verify the expired message and re-login prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)